### PR TITLE
Bump tmpl from 1.0.4 to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9396,9 +9396,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-arraybuffer": {


### PR DESCRIPTION
Bumps [tmpl](https://github.com/daaku/nodejs-tmpl) de la 1.0.4 la 1.0.5. - [Note de lansare](https://github.com/daaku/nodejs-tmpl/releases) - [Commits](https://github.com/daaku/nodejs-tmpl/commits/v1.0.5) --- actualizate-dependențe: - dependență-nume: tmpl dependență-tip: indirect ... Semnat-off-by: dependabot[bot] <support@github.com>